### PR TITLE
Fix undeclared identifier 'PHP_STREAM_KEEP_RSRC'

### DIFF
--- a/main/streams/cast.c
+++ b/main/streams/cast.c
@@ -86,7 +86,7 @@ static int stream_cookie_closer(void *cookie)
 
 	/* prevent recursion */
 	stream->fclose_stdiocast = PHP_STREAM_FCLOSE_NONE;
-	return php_stream_free(stream, PHP_STREAM_FREE_CLOSE | PHP_STREAM_KEEP_RSRC);
+	return php_stream_free(stream, PHP_STREAM_FREE_CLOSE | PHP_STREAM_FREE_KEEP_RSRC);
 }
 #elif defined(HAVE_FOPENCOOKIE)
 static ssize_t stream_cookie_reader(void *cookie, char *buffer, size_t size)


### PR DESCRIPTION
Identifier named `PHP_STREAM_FREE_KEEP_RSRC`  but use `PHP_STREAM_KEEP_RSRC`

Reference Line 131